### PR TITLE
Correct URL for media stubs

### DIFF
--- a/resources/lib/Utils.py
+++ b/resources/lib/Utils.py
@@ -30,11 +30,13 @@ class PlayUtils():
           if playurl != None:
             #We have a path to play so play it
             USER_AGENT = 'QuickTime/7.7.4'
-        
-            if (result.get("VideoType") == "Dvd"):
-              playurl = playurl + "/VIDEO_TS/VIDEO_TS.IFO"
-            if (result.get("VideoType") == "BluRay"):
-              playurl = playurl + "/BDMV/index.bdmv"            
+
+            # If the file it is not a media stub
+            if (result.get("IsPlaceHolder") != True):
+              if (result.get("VideoType") == "Dvd"):
+                playurl = playurl + "/VIDEO_TS/VIDEO_TS.IFO"
+              elif (result.get("VideoType") == "BluRay"):
+                playurl = playurl + "/BDMV/index.bdmv"
             if addonSettings.getSetting('smbusername') == '':
               playurl = playurl.replace("\\\\", "smb://")
             else:


### PR DESCRIPTION
If the file is a media stub, we don't check the **VideoType** because that will change the URL and we don't want that. We will just use the path.

This came from this thread http://mediabrowser.tv/community/index.php?/topic/10103-show-media-stubs-message/
