### PR TITLE
Show the corresponding media stubs message

### DIFF
--- a/default.py
+++ b/default.py
@@ -854,7 +854,7 @@ def PLAY( url, handle ):
     setListItemProps(server, id, listItem, result)
 
     # Can not play virtual items
-    if (result.get("LocationType") == "Virtual") or (result.get("IsPlaceholder")=="true"):
+    if (result.get("LocationType") == "Virtual"):
         xbmcgui.Dialog().ok(__language__(30128), __language__(30129))
         return
 
@@ -950,7 +950,7 @@ def PLAYPlaylist( url, handle ):
         setListItemProps(server, id, listItem, result)
 
         # Can not play virtual items
-        if (result.get("LocationType") == "Virtual") or (result.get("IsPlaceholder")=="true"):
+        if (result.get("LocationType") == "Virtual") or (result.get("IsPlaceHolder") == True):
             xbmcgui.Dialog().ok(__language__(30128), __language__(30129))
             return
 


### PR DESCRIPTION
When playing media stubs file, nothing happens. A dialog asking you to insert the disc should open.
There was a typo in the **IsPlaceHolder** property and the wrong URL was returned by the **getPlayUrl()** function.

This fix the **PLAY** method by showing the correct dialog. I didn't do the same with **PLAYPlaylist** because I'm not sure what it does. For the **PLAYPlaylist**, the "This item is not playable" dialog will appear, which it wasn't showing because of the typos.

This came from here: http://mediabrowser.tv/community/index.php?/topic/10103-show-media-stubs-message/
