### PR TITLE
Fix a potential wrong operator bug

### DIFF
--- a/resources/lib/SkinHelperThread.py
+++ b/resources/lib/SkinHelperThread.py
@@ -96,7 +96,7 @@ class SkinHelperThread(threading.Thread):
         if WINDOW.getProperty("MediaBrowser.usr.Count") != '':
             totalUserLinks = int(WINDOW.getProperty("MediaBrowser.usr.Count"))
         linkCount = 0
-        while linkCount !=totalUserLinks:
+        while linkCount < totalUserLinks:
             mbstring = "MediaBrowser.usr." + str(linkCount)
             if xbmc.getInfoLabel("Skin.String(" + mbstring + '.background)') != "":
                 WINDOW.setProperty(mbstring + '.background', xbmc.getInfoLabel("Skin.String(" + mbstring + '.background)'))


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential wrong operator bug at `resources/lib/SkinHelperThread.py`. Please check the changes.

If `totalUserLinks` is a negative number, it will run into infinite loop. Using `<` would prevent this.

Best,
Jingxuan